### PR TITLE
Added new parameter to set basedir on build command (--basedir)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Changes file for OPM::Maker
 ===========================
 
+1.15 2022-01-18 22:48:00
+
+  + add new parameter to set basedir on build command
+
 1.14 2022-01-17 14:09:00
 
   + fix version in info command

--- a/lib/OPM/Maker/Command/build.pm
+++ b/lib/OPM/Maker/Command/build.pm
@@ -19,12 +19,13 @@ sub abstract {
 }
 
 sub usage_desc {
-    return "opmbuild build [--version <version>] [--output <output_path>] <path_to_sopm>";
+    return "opmbuild build [--version <version>] [--basedir <output_path>] [--output <output_path>] <path_to_sopm>";
 }
 
 sub opt_spec {
     return (
         [ "output=s",  "Output path for OPM file" ],
+        [ "basedir=s",  "Base directory of SOPM files" ],
         [ "version=s", "Version to be used (override the one from the sopm file)" ],
     );
 }
@@ -87,7 +88,8 @@ sub execute {
     FILE:
     for my $file ( @files ) {
         my $name         = $file->findvalue( '@Location' );
-        my $file_path    = Path::Class::File->new( $path, $name );
+        my $file_path    = Path::Class::File->new( 
+            $opt->{basedir} ? $opt->{basedir} : $path, $name );
         my $file_content = $file_path->slurp;
         my $base64       = MIME::Base64::encode( $file_content );
         

--- a/t/build/04_subs.t
+++ b/t/build/04_subs.t
@@ -18,13 +18,14 @@ my $build = OPM::Maker::Command::build->new({
 
 {
     my $return = $build->usage_desc;
-    is $return, 'opmbuild build [--version <version>] [--output <output_path>] <path_to_sopm>';
+    is $return, 'opmbuild build [--version <version>] [--basedir <output_path>] [--output <output_path>] <path_to_sopm>';
 }
 
 {
     my @return = $build->opt_spec;
     my $check  = [
         [ "output=s",  "Output path for OPM file" ],
+        [ "basedir=s",  "Base directory of SOPM files" ],
         [ "version=s", "Version to be used (override the one from the sopm file)" ],
     ];
     is_deeply \@return, $check;


### PR DESCRIPTION
Once you build package from a subdirectory like packages/APP/APP.sopm you need package files inplace, after this changes it's possible to build package without copying all stuffs to package dir like in official opm builder in OTRS console
